### PR TITLE
Fixed typo causing crash in threshold_restorer

### DIFF
--- a/mps_manager/threshold_restorer.py
+++ b/mps_manager/threshold_restorer.py
@@ -68,7 +68,7 @@ class ThresholdRestorer:
       print(self.error_message)
       print('Name: {}'.format(self.app.name))
       print('Description: {}'.format(self.app.description))
-      print('Crate: {}, Slot: {}'.format(self.app.crate.get_name(), app.slot_number))
+      print('Crate: {}, Slot: {}'.format(self.app.crate.get_name(), self.app.slot_number))
       return None
 
     print('Name: {}'.format(self.app.name))


### PR DESCRIPTION
When sending the wrong app ID the request hangs on the application side and mps_manager crashes. This crash was due to accessing a variable that was in the instance scope but not at global scope.